### PR TITLE
Fix dump_keys function. Address argument is optional

### DIFF
--- a/src/neofs_testlib/cli/neogo/wallet.py
+++ b/src/neofs_testlib/cli/neogo/wallet.py
@@ -148,7 +148,7 @@ class NeoGoWallet(CliCommand):
 
     def dump_keys(
         self,
-        address: str,
+        address: Optional[str] = None,
         wallet: Optional[str] = None,
         wallet_config: Optional[str] = None,
     ) -> CommandResult:


### PR DESCRIPTION
Signed-off-by: a.lipay <a.lipay@yadro.com>