### PR TITLE
Add logs with time if command failed by timeout

### DIFF
--- a/src/neofs_testlib/shell/local_shell.py
+++ b/src/neofs_testlib/shell/local_shell.py
@@ -96,7 +96,7 @@ class LocalShell(Shell):
                 f"return code: {exc.returncode}\n"
                 f"output: {exc.output}"
             ) from exc
-        except OSError as exc:
+        except (OSError, subprocess.SubprocessError) as exc:
             raise RuntimeError(f"Command: {command}\nOutput: {exc.strerror}") from exc
         finally:
             end_time = datetime.utcnow()


### PR DESCRIPTION
Execute finally (add logs) if failed with timeout in local _exec_non_interactive()

Signed-off-by: Vladimir Avdeev <v.avdeev@yadro.com>